### PR TITLE
Exclude owncloud-news-gitter-bot from mention bot

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -27,6 +27,7 @@
   "userBlacklist": [
     "owncloud-bot",
     "scrutinizer-auto-fixer",
+    "owncloud-news-gitter-bot",
     "th3fallen",
     "zander"
   ]


### PR DESCRIPTION
As seen in e.g. https://github.com/owncloud/documentation/pull/2507